### PR TITLE
chore: Update sidetree-core-go revision to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.0.0-20191030160623-b6a8afec3cb8
+	github.com/trustbloc/sidetree-core-go v0.1.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -61,11 +61,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191028174235-80e3b92d0da1 h1:uJdOEwzFYMpFLIFl28+zutAoIyihF591ZDLdCKD9VMM=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191028174235-80e3b92d0da1/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191030143807-717ed28e9b4d/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191030160623-b6a8afec3cb8 h1:OsfQluDIg4hz//oI3f9JewCQyOSKxkLsjGI7SioqhTs=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191030160623-b6a8afec3cb8/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
+github.com/trustbloc/sidetree-core-go v0.1.0 h1:XO7up5EK3FfqzijCJHXt0Cidd6XfN/RO6ifAR0mZXbU=
+github.com/trustbloc/sidetree-core-go v0.1.0/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 gitlab.com/NebulousLabs/errors v0.0.0-20171229012116-7ead97ef90b8 h1:gZfMjx7Jr6N8b7iJO4eUjDsn6xJqoyXg8D+ogdoAfKY=

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
-	github.com/trustbloc/sidetree-core-go v0.0.0-20191030160623-b6a8afec3cb8
+	github.com/trustbloc/sidetree-core-go v0.1.0
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -73,10 +73,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191028174235-80e3b92d0da1 h1:uJdOEwzFYMpFLIFl28+zutAoIyihF591ZDLdCKD9VMM=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191028174235-80e3b92d0da1/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191030143807-717ed28e9b4d/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
-github.com/trustbloc/sidetree-core-go v0.0.0-20191030160623-b6a8afec3cb8/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
+github.com/trustbloc/sidetree-core-go v0.1.0 h1:XO7up5EK3FfqzijCJHXt0Cidd6XfN/RO6ifAR0mZXbU=
+github.com/trustbloc/sidetree-core-go v0.1.0/go.mod h1:FC7RAK7yPS2Y7iKQL2gt01fVi1JtYLbpUklNYcxCfYQ=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=


### PR DESCRIPTION
closes #87

Signed-off-by: Firas Qutishat <firas.qutishat@securekey.com>