### PR TITLE
chore: Update to latest sidetree-core-go

### DIFF
--- a/cmd/sidetree-server/main.go
+++ b/cmd/sidetree-server/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
 	"github.com/trustbloc/sidetree-core-go/pkg/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/dochandler"
 	"github.com/trustbloc/sidetree-core-go/pkg/dochandler/didvalidator"
@@ -24,6 +25,7 @@ import (
 
 	sidetreecontext "github.com/trustbloc/sidetree-mock/pkg/context"
 	"github.com/trustbloc/sidetree-mock/pkg/httpserver"
+	"github.com/trustbloc/sidetree-mock/pkg/mocks"
 	"github.com/trustbloc/sidetree-mock/pkg/observer"
 )
 
@@ -40,7 +42,9 @@ func main() {
 
 	logger.Info("starting sidetree node...")
 
-	ctx, err := sidetreecontext.New(config)
+	opStore := mocks.NewMockOperationStore()
+
+	ctx, err := sidetreecontext.New(opStore)
 	if err != nil {
 		logger.Errorf("Failed to create new context: %s", err.Error())
 		panic(err)
@@ -63,7 +67,7 @@ func main() {
 	batchWriter.Start()
 
 	// start observer
-	observer.Start(ctx.Blockchain(), ctx.CAS(), ctx.OperationStore())
+	observer.Start(ctx.Blockchain(), ctx.CAS(), mocks.NewMockOpStoreProvider(opStore))
 
 	// did document handler with did document validator for didDocNamespace
 	didDocHandler := dochandler.New(

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a h1:LIgc1RapeZFIVhuiuTcXX/Kxe9NegkqqzCKTtq3o2ko=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -7,28 +7,25 @@ SPDX-License-Identifier: Apache-2.0
 package context
 
 import (
-	"github.com/spf13/viper"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/cutter"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/opqueue"
-	"github.com/trustbloc/sidetree-core-go/pkg/processor"
-
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+	"github.com/trustbloc/sidetree-core-go/pkg/processor"
 
 	servermocks "github.com/trustbloc/sidetree-mock/pkg/mocks"
 )
 
-func New(cfg *viper.Viper) (*ServerContext, error) { // nolint
+func New(opStoreClient processor.OperationStoreClient) (*ServerContext, error) { // nolint
 
-	opsStore := mocks.NewMockOperationStore(nil)
 	cas := servermocks.NewMockCasClient(nil)
 
 	ctx := &ServerContext{
 		ProtocolClient:       servermocks.NewMockProtocolClient(),
 		CasClient:            cas,
 		BlockchainClient:     mocks.NewMockBlockchainClient(nil),
-		OperationStoreClient: opsStore,
+		OperationStoreClient: opStoreClient,
 		OpQueue:              &opqueue.MemQueue{},
 	}
 
@@ -41,7 +38,7 @@ type ServerContext struct {
 	ProtocolClient       *servermocks.MockProtocolClient
 	CasClient            *servermocks.MockCasClient
 	BlockchainClient     *mocks.MockBlockchainClient
-	OperationStoreClient *mocks.MockOperationStore
+	OperationStoreClient processor.OperationStoreClient
 	OpQueue              *opqueue.MemQueue
 }
 

--- a/pkg/mocks/operationstore.go
+++ b/pkg/mocks/operationstore.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/observer"
+)
+
+// MockOpStoreProvider is a mock operation store provider
+type MockOpStoreProvider struct {
+	opStore observer.OperationStore
+}
+
+// NewMockOpStoreProvider returns a new mock operation store provider
+func NewMockOpStoreProvider(opStore observer.OperationStore) *MockOpStoreProvider {
+	return &MockOpStoreProvider{opStore: opStore}
+}
+
+// ForNamespace returns a mock operation store for the given namespace
+func (m *MockOpStoreProvider) ForNamespace(string) (observer.OperationStore, error) {
+	return m.opStore, nil
+}
+
+// MockOperationStore is a mock operation store
+type MockOperationStore struct {
+	sync.RWMutex
+	operations map[string][]*batch.Operation
+}
+
+// NewMockOperationStore returns a new mock operation store
+func NewMockOperationStore() *MockOperationStore {
+	return &MockOperationStore{operations: make(map[string][]*batch.Operation)}
+}
+
+// Put stores the given operations
+func (m *MockOperationStore) Put(ops []*batch.Operation) error {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, op := range ops {
+		fmt.Printf("Putting operation %+v\n", op)
+		m.operations[op.UniqueSuffix] = append(m.operations[op.UniqueSuffix], op)
+	}
+
+	fmt.Printf("Have operations: %+v\n", m.operations)
+	return nil
+}
+
+// Get retrieves the operations for the given suffix
+func (m *MockOperationStore) Get(suffix string) ([]*batch.Operation, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	ops := m.operations[suffix]
+	if len(ops) == 0 {
+		return nil, errors.New("uniqueSuffix not found in the store")
+	}
+
+	return ops, nil
+}

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -7,23 +7,35 @@ package observer
 
 import (
 	"encoding/json"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
-	batchapi "github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/observer"
+	"github.com/trustbloc/sidetree-mock/pkg/mocks"
 )
 
 func TestStartObserver(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
+		var rw sync.RWMutex
 		txNum := make(map[uint64]*struct{}, 0)
 		hits := 0
-		var rw sync.RWMutex
+
+		opStore := &mockOperationStoreClient{putFunc: func(ops []*batch.Operation) error {
+			rw.Lock()
+			defer rw.Unlock()
+
+			for _, op := range ops {
+				txNum[op.TransactionNumber] = nil
+				hits++
+			}
+
+			return nil
+		}}
+
 		Start(&mockBlockchainClient{readValue: []*observer.SidetreeTxn{{AnchorAddress: "anchorAddress", TransactionNumber: 0},
 			{AnchorAddress: "anchorAddress", TransactionNumber: 1}}}, mockCASClient{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
@@ -32,13 +44,7 @@ func TestStartObserver(t *testing.T) {
 			b, err := json.Marshal(batch.Operation{ID: "did:sidetree:1234"})
 			require.NoError(t, err)
 			return json.Marshal(&observer.BatchFile{Operations: []string{docutil.EncodeToString(b)}})
-		}}, mockOperationStoreClient{putFunc: func(ops *batch.Operation) error {
-			rw.Lock()
-			txNum[ops.TransactionNumber] = nil
-			hits++
-			rw.Unlock()
-			return nil
-		}})
+		}}, mocks.NewMockOpStoreProvider(opStore))
 		time.Sleep(2000 * time.Millisecond)
 		rw.RLock()
 		require.Equal(t, 2, hits)
@@ -49,14 +55,6 @@ func TestStartObserver(t *testing.T) {
 		require.True(t, ok)
 		rw.RUnlock()
 
-	})
-
-	t.Run("test error from operationStore put", func(t *testing.T) {
-		err := operationStore{operationStoreClient: mockOperationStoreClient{putFunc: func(ops *batch.Operation) error {
-			return fmt.Errorf("put error")
-		}}}.Put([]*batchapi.Operation{&batch.Operation{ID: "did:sidetree:1234", Type: "1"}})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "put in operation store failed")
 	})
 }
 
@@ -92,16 +90,12 @@ func (m mockCASClient) Read(key string) ([]byte, error) {
 }
 
 type mockOperationStoreClient struct {
-	putFunc func(ops *batch.Operation) error
+	putFunc func(ops []*batch.Operation) error
 }
 
-func (m mockOperationStoreClient) Get(uniqueSuffix string) ([]*batch.Operation, error) {
-	return nil, nil
-}
-
-func (m mockOperationStoreClient) Put(op *batch.Operation) error {
+func (m mockOperationStoreClient) Put(ops []*batch.Operation) error {
 	if m.putFunc != nil {
-		return m.putFunc(op)
+		return m.putFunc(ops)
 	}
 	return nil
 }

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -75,6 +75,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a h1:LIgc1RapeZFIVhuiuTcXX/Kxe9NegkqqzCKTtq3o2ko=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=


### PR DESCRIPTION
Point to latest sidetree-core-go which allows for a different operation store for each namespace.

closes #138

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>