### PR TITLE
chore: Renamed resolution endpoint to /identifiers

### DIFF
--- a/cmd/sidetree-server/main.go
+++ b/cmd/sidetree-server/main.go
@@ -33,7 +33,7 @@ var logger = logrus.New()
 var config = viper.New()
 
 const defaultDIDDocNamespace = "did:sidetree"
-const basePath = "/document"
+const basePath = "/sidetree/0.0.1"
 
 func main() {
 	config.SetEnvPrefix("SIDETREE_MOCK")

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,26 +12,26 @@ Sidetree REST API
 
 Request Path ::
 
- Post /document
+ Post /sidetree/0.0.1/operations
 
 
 **DID Document resolution**
 
 Request Path ::
 
- GET  /document/{DidOrDidDocument}
+ GET  /sidetree/0.0.1/identifiers/{DidOrDidDocument}
 
 **Updating a DID Document**
 
 Request Path ::
 
- Post /document
+ Post /sidetree/0.0.1/operations
 
 **DID Deletion**
 
 Request Path ::
 
-  Post /document
+ Post /sidetree/0.0.1/operations
 
 **DID Resolution**
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b h1:M66/b+yyuzae5tiktRLN9XzoaQSsworNZ+xf7FFPUyg=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -34,12 +34,16 @@ const (
 	clientURL = "http://" + url
 
 	didDocNamespace = "did:sidetree"
-	basePath        = "/document"
-	baseUpdatePath  = "/document/operations"
+	basePath        = "/sidetree/0.0.1"
 
 	sha2_256        = 18
 	sampleNamespace = "sample:sidetree"
 	samplePath      = "/sample"
+)
+
+var (
+	baseResolvePath = basePath + "/identifiers"
+	baseUpdatePath  = basePath + "/operations"
 )
 
 func TestServer_Start(t *testing.T) {
@@ -83,7 +87,7 @@ func TestServer_Start(t *testing.T) {
 		require.Equal(t, didID, result.Document["id"])
 	})
 	t.Run("Resolve DID doc", func(t *testing.T) {
-		resp, err := httpGet(t, clientURL+basePath+"/"+didID)
+		resp, err := httpGet(t, clientURL+baseResolvePath+"/"+didID)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -35,8 +35,8 @@ var logger = logrus.New()
 const (
 	didDocNamespace        = "did:sidetree:test"
 	initialStateParam      = "?-sidetree-initial-state="
-	testDocumentResolveURL = "https://localhost:48326/document"
-	testDocumentUpdateURL  = "https://localhost:48326/document/operations"
+	testDocumentResolveURL = "https://localhost:48326/sidetree/0.0.1/identifiers"
+	testDocumentUpdateURL  = "https://localhost:48326/sidetree/0.0.1/operations"
 
 	sha2_256            = 18
 	recoveryRevealValue = "recoveryOTP"

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -92,8 +92,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b h1:M66/b+yyuzae5tiktRLN9XzoaQSsworNZ+xf7FFPUyg=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=


### PR DESCRIPTION
Also updated the base path to /sidetree/0.0.1 to make it compatible with the spec.

closes #171

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>