### PR TITLE
chore: update sidetree-mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670 h1:i1rUTcU9IokHsf4DMftvdCYmD8lOKjmsSDVWD6FcgO8=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -292,7 +292,7 @@ func (d *DIDSideSteps) checkSuccessResp(msg string, contains bool) error {
 		didDoc := document.DidDocumentFromJSONLDObject(result.Document)
 
 		// perform basic checks on document
-		if didDoc.ID() == "" || didDoc.Context()[0] != "https://w3id.org/did/v1" ||
+		if didDoc.ID() == "" || didDoc.Context()[0] != "https://www.w3.org/ns/did/v1" ||
 			!strings.Contains(didDoc.PublicKeys()[0].Controller(), didDoc.ID()) {
 			return errors.New("response is not a valid did document")
 		}
@@ -346,7 +346,7 @@ func (d *DIDSideSteps) getCreateRequest(doc []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	d.recoveryKeySigner = ecsigner.New(privateKey, "ES256", "recovery")
+	d.recoveryKeySigner = ecsigner.New(privateKey, "ES256", "")
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +392,7 @@ func (d *DIDSideSteps) getRecoverRequest(doc []byte, uniqueSuffix string) ([]byt
 	}
 
 	// update recovery key singer for subsequent requests
-	d.recoveryKeySigner = ecsigner.New(newPrivateKey, "ES256", "recovery")
+	d.recoveryKeySigner = ecsigner.New(newPrivateKey, "ES256", "")
 
 	return recoverRequest, nil
 }

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -92,8 +92,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670 h1:i1rUTcU9IokHsf4DMftvdCYmD8lOKjmsSDVWD6FcgO8=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=


### PR DESCRIPTION
Sidetree changes include:
- kid must not be provided for recovery and deactivate
- kid must be provided for update
- helper signers accommodated for those scenarios
- add signing model for update, not just string (DELTA_HASH)
- remove option to update document using recovery key (document has to have at least one ops key)
- check delta against signed delta hash for update and recovery
- validate info against signed data for deactivate
- update document context as per latest spec
- resolution returns bad request in case of validation error

Closes #175

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>