### PR TITLE
chore: Update sidetree-core - service validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b h1:wVscI1/+oJq3bYvyPiRTytZo9+HCU0GZ76wuGzAQbGQ=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836 h1:moG4HZ0GMQRg4ksr8Gu1URw9fQBIitYwgWs9zQMgkWo=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -246,7 +246,7 @@ func getCreateRequest() ([]byte, error) {
 
 const validDoc = `{
 	"publicKey": [{
-		"id": "#key-1",
+		"id": "key-1",
 		"usage": ["general"],
 		"type": "JwsVerificationKey2020",
 		"jwk": {

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -78,13 +78,13 @@ const docTemplate = `{
   		"jwk": %s
 	},
    {
-     "id": "dual-auth-general",
+     "id": "dual-auth-gen",
      "type": "JwsVerificationKey2020",
      "usage": ["auth", "general"],
      "jwk": %s
    },
    {
-     "id": "dual-assertion-general",
+     "id": "dual-assertion-gen",
      "type": "Ed25519VerificationKey2018",
      "usage": ["assertion", "general"],
      "jwk": %s

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428212404-9f9bd5c0a9ce
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -94,6 +94,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428212404-9f9bd5c0a9ce h1:F7yjRZB5WD2dyFDvDQAnxt4e58KGLimFjl1YpLe3usM=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428212404-9f9bd5c0a9ce/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836 h1:moG4HZ0GMQRg4ksr8Gu1URw9fQBIitYwgWs9zQMgkWo=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=


### PR DESCRIPTION
Included:
- add service patch validation
- pub key and service id validation
- initial document validation includes services
- validation of all patches when parsing operation deltas (before operation is accepted)
- remove public keys and remove services patch validation

Close #185

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>