### PR TITLE
chore: Rename sidetree to sidetree-mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DEV_IMAGES         = $(shell docker images dev-* -q)
 ARCH               = $(shell go env GOARCH)
 GO_VER             = 1.13.4
 
-# Namespace for the sidetree node
+# Namespace for the sidetree mock node
 DOCKER_OUTPUT_NS          ?= trustbloc
 SIDETREE_MOCK_IMAGE_NAME  ?= sidetree-mock
 
@@ -47,12 +47,12 @@ unit-test:
 
 all: clean checks unit-test bddtests
 
-sidetree:
-	@echo "Building sidetree"
+sidetree-mock:
+	@echo "Building sidetree-mock"
 	@mkdir -p ./.build/bin
 	@go build -o ./.build/bin/sidetree-mock cmd/sidetree-server/main.go
 
-sidetree-docker: sidetree
+sidetree-mock-docker: sidetree-mock
 	@docker build -f ./images/sidetree-mock/Dockerfile --no-cache -t $(DOCKER_OUTPUT_NS)/$(SIDETREE_MOCK_IMAGE_NAME):latest \
 	--build-arg GO_VER=$(GO_VER) \
 	--build-arg ALPINE_VER=$(ALPINE_VER) \
@@ -77,7 +77,7 @@ generate-test-keys:
 		--entrypoint "/opt/workspace/sidetree-mock/scripts/generate_test_keys.sh" \
 		frapsoft/openssl
 
-bddtests: generate-test-keys sidetree-docker
+bddtests: generate-test-keys sidetree-mock-docker
 	@scripts/integration.sh
 
 clean:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
           trap logout EXIT
           source ci/version_var.sh
           echo $DOCKER_PASSWORD | docker login docker.pkg.github.com --username $DOCKER_USER --password-stdin
-          make sidetree-docker
+          make sidetree-mock-docker
           docker tag trustbloc/sidetree-mock:latest ${SIDETREE_MOCK_PKG}:${SIDETREE_MOCK_TAG}
           docker push ${SIDETREE_MOCK_PKG}:${SIDETREE_MOCK_TAG}
         env:

--- a/images/sidetree-mock/Dockerfile
+++ b/images/sidetree-mock/Dockerfile
@@ -19,12 +19,12 @@ ADD . $GOPATH/src/github.com/trustbloc/sidetree-mock
 WORKDIR $GOPATH/src/github.com/trustbloc/sidetree-mock
 ENV EXECUTABLES go git
 
-FROM golang as sidetree
+FROM golang as sidetree-mock
 ARG GO_TAGS
 ARG GOPROXY
-RUN GO_TAGS=${GO_TAGS} GOPROXY=${GOPROXY} make sidetree
+RUN GO_TAGS=${GO_TAGS} GOPROXY=${GOPROXY} make sidetree-mock
 
 
 FROM alpine:${ALPINE_VER} as base
-COPY --from=sidetree /go/src/github.com/trustbloc/sidetree-mock/.build/bin/sidetree-mock /usr/local/bin
+COPY --from=sidetree-mock /go/src/github.com/trustbloc/sidetree-mock/.build/bin/sidetree-mock /usr/local/bin
 CMD ["sidetree-mock"]


### PR DESCRIPTION
Rename sidetree to sidetree-mock in Makefile, Dockerfile, Azure pipelines to be consistent with other projects.

Closes #198

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>