### PR TITLE
chore: update sidetree-core (commitment changes)

### DIFF
--- a/cmd/sidetree-server/main.go
+++ b/cmd/sidetree-server/main.go
@@ -75,7 +75,7 @@ func main() {
 		ctx.Protocol(),
 		didvalidator.New(ctx.OperationStore()),
 		batchWriter,
-		processor.New(didDocNamespace, ctx.OperationStore()),
+		processor.New(didDocNamespace, ctx.OperationStore(), mocks.NewMockProtocolClient()),
 	)
 
 	restSvc := httpserver.New(

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b h1:7s3Vq39k3lI0P6q3SccW6un3Sbk04lbRYo5bzzLMVsQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07 h1:W0LTy0UdxiDjg65TH/4wS7J5pAv+HSZGl6gsOqwk0g8=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -257,14 +258,22 @@ func (h *sampleResolveHandler) Handler() common.HTTPRequestHandler {
 }
 
 func getCreateRequest() ([]byte, error) {
+	testKey := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+	}
+
+	c, err := commitment.Calculate(testKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	info := &helper.CreateRequestInfo{
-		OpaqueDocument: validDoc,
-		RecoveryKey: &jws.JWK{
-			Kty: "kty",
-			Crv: "crv",
-			X:   "x",
-		},
-		MultihashCode: sha2_256,
+		OpaqueDocument:     validDoc,
+		RecoveryCommitment: c,
+		UpdateCommitment:   c,
+		MultihashCode:      sha2_256,
 	}
 	return helper.NewCreateRequest(info)
 }

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler/models"
@@ -117,11 +116,7 @@ func (m mockOperationStoreClient) Put(ops []*batch.Operation) error {
 func getSuffixData() string {
 	model := &model.SuffixDataModel{
 		DeltaHash: getEncodedMultihash([]byte(validDoc)),
-		RecoveryKey: &jws.JWK{
-			Kty: "kty",
-			Crv: "crv",
-			X:   "x",
-		},
+
 		RecoveryCommitment: getEncodedMultihash([]byte("commitment")),
 	}
 

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -92,8 +92,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b h1:7s3Vq39k3lI0P6q3SccW6un3Sbk04lbRYo5bzzLMVsQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07 h1:W0LTy0UdxiDjg65TH/4wS7J5pAv+HSZGl6gsOqwk0g8=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=


### PR DESCRIPTION
Sidetree core has been modified with commitment changes:
- generate recovery and update commitments from corresponding public JWK during create
- add update key to update request
- add recovery key for deactivate and recover requests
- validate keys against previously provided commitments
- validate signature against passed in keys
- return update and recovery commitments in resolution result metadata (remove recovery key and operation keys)

Closes #217

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>