### PR TITLE
chore: update sidetree-core (enable replace patch action param)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200728201450-58863c04070e
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da h1:WeCXxLZ3/WJCeOZo7WqVmG2xAni8+ikvT3/4X7L/1+g=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200728201450-58863c04070e h1:DxA9K4lyr5OM3AHrQgDdvY7725k7GBwNtiHMNRVEqVM=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200728201450-58863c04070e/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -30,6 +30,7 @@ func NewMockProtocolClient() *MockProtocolClient {
 		MaxChunkFileSize:             maxBatchFileSize,
 		MaxMapFileSize:               maxBatchFileSize,
 		MaxAnchorFileSize:            maxBatchFileSize,
+		EnableReplacePatch:           true,
 	}
 
 	// has to be sorted for mock client to work

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200728201450-58863c04070e
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da h1:WeCXxLZ3/WJCeOZo7WqVmG2xAni8+ikvT3/4X7L/1+g=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200728201450-58863c04070e h1:DxA9K4lyr5OM3AHrQgDdvY7725k7GBwNtiHMNRVEqVM=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200728201450-58863c04070e/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Enable replace patch action in order to run interop tests.

Closes #234

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>