### PR TITLE
chore: update sidetree-core (double hash JWK for commitment)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200904134412-6c2efa84f694
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287 h1:IVezingwhCb8D0UtzDRxWbSVr3H1rAvm29VNY+Lcv3Y=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200904134412-6c2efa84f694 h1:eOGjUCAEFiyUCfqJxXBxDhovyXqSFu4pjyuelyZTY9k=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200904134412-6c2efa84f694/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -9,6 +9,7 @@ package httpserver
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -264,7 +265,7 @@ func getCreateRequest() ([]byte, error) {
 		X:   "x",
 	}
 
-	c, err := commitment.Calculate(testKey, sha2_256)
+	c, err := commitment.Calculate(testKey, sha2_256, crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -24,6 +24,7 @@ func NewMockProtocolClient() *MockProtocolClient {
 	latest := protocol.Protocol{
 		GenesisTime:                  0,
 		HashAlgorithmInMultiHashCode: 18,
+		HashAlgorithm:                5, // crypto code for sha256 hash function
 		MaxOperationCount:            1, // one operation per batch - batch gets cut right away
 		MaxOperationSize:             200000,
 		CompressionAlgorithm:         "GZIP",

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -9,5 +9,9 @@ set -e
 echo "Running sidetree-mock integration tests..."
 PWD=`pwd`
 cd test/bddtests
-go test -count=1 -v -cover . -p 1 -timeout=20m
+go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_resolve_with_initial_value,interop_create_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_recover_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_deactivate_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_update_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
 cd $PWD

--- a/test/bddtests/bddtests_test.go
+++ b/test/bddtests/bddtests_test.go
@@ -21,10 +21,15 @@ import (
 var composition *Composition
 
 func TestMain(m *testing.M) {
-
 	// default is to run all tests with tag @all
 	tags := "all"
+
+	if os.Getenv("TAGS") != "" {
+		tags = os.Getenv("TAGS")
+	}
+
 	flag.Parse()
+
 	cmdTags := flag.CommandLine.Lookup("test.run")
 	if cmdTags != nil && cmdTags.Value != nil && cmdTags.Value.String() != "" {
 		tags = cmdTags.Value.String()
@@ -46,12 +51,11 @@ func TestMain(m *testing.M) {
 
 				composition = newComposition
 
-				fmt.Println("docker-compose up ... waiting for peer to start ...")
 				testSleep := 5
 				if os.Getenv("TEST_SLEEP") != "" {
 					testSleep, _ = strconv.Atoi(os.Getenv("TEST_SLEEP"))
 				}
-				fmt.Printf("*** testSleep=%d", testSleep)
+				fmt.Println(fmt.Sprintf("docker-compose up with tags=%s ... waiting for peer to start for %d seconds", tags, testSleep))
 				time.Sleep(time.Second * time.Duration(testSleep))
 			}
 

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package bddtests
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -470,7 +471,7 @@ func generateKeyAndCommitment() (*ecdsa.PrivateKey, string, error) {
 		return nil, "", err
 	}
 
-	c, err := commitment.Calculate(pubKey, sha2_256)
+	c, err := commitment.Calculate(pubKey, sha2_256, crypto.SHA256)
 	if err != nil {
 		return nil, "", err
 	}

--- a/test/bddtests/features/interop.feature
+++ b/test/bddtests/features/interop.feature
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-@all
+# Each test has to be run on fresh system since create document is the same for all tests
 @did-interop
 Feature:
 

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.4
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200904134412-6c2efa84f694
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.4 h1:rnHipgA4mqR7J/cNgen4ZjaghCV0UaEKwVo3j38NDRY=
-github.com/trustbloc/sidetree-core-go v0.1.4/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200904134412-6c2efa84f694 h1:eOGjUCAEFiyUCfqJxXBxDhovyXqSFu4pjyuelyZTY9k=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200904134412-6c2efa84f694/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Update sidetree-core:
- double hash JWK for commitment
- reorganize interop tests since they were changed to use same create for testing all operations

Closes #253

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>