### PR TITLE
chore: Update to latest sidetree-core-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200914191732-143e6dac7d0f
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200918194037-fdbce8c6dd49
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200914191732-143e6dac7d0f h1:w11QrvIZmSG+I24ZmKPFmBwqXeTXD08Q2fXOXJ05iuI=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200914191732-143e6dac7d0f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200918194037-fdbce8c6dd49 h1:jnwkj3Zf81yhQHUKpesDna4bRIBkk4moKtDyM1QPYB4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200918194037-fdbce8c6dd49/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -7,40 +7,27 @@ SPDX-License-Identifier: Apache-2.0
 package context
 
 import (
-	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/cutter"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/opqueue"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
-	"github.com/trustbloc/sidetree-core-go/pkg/processor"
-
-	servermocks "github.com/trustbloc/sidetree-mock/pkg/mocks"
 )
 
-func New(opStoreClient processor.OperationStoreClient) (*ServerContext, error) { // nolint
-
-	cas := servermocks.NewMockCasClient(nil)
-
-	ctx := &ServerContext{
-		ProtocolClient:       servermocks.NewMockProtocolClient(),
-		CasClient:            cas,
-		BlockchainClient:     mocks.NewMockBlockchainClient(nil),
-		OperationStoreClient: opStoreClient,
-		OpQueue:              &opqueue.MemQueue{},
+// New returns a new server context
+func New(pc protocol.Client) *ServerContext {
+	return &ServerContext{
+		ProtocolClient:   pc,
+		BlockchainClient: mocks.NewMockBlockchainClient(nil),
+		OpQueue:          &opqueue.MemQueue{},
 	}
-
-	return ctx, nil
-
 }
 
 // ServerContext implements batch context
 type ServerContext struct {
-	ProtocolClient       *servermocks.MockProtocolClient
-	CasClient            *servermocks.MockCasClient
-	BlockchainClient     *mocks.MockBlockchainClient
-	OperationStoreClient processor.OperationStoreClient
-	OpQueue              *opqueue.MemQueue
+	ProtocolClient   protocol.Client
+	BlockchainClient *mocks.MockBlockchainClient
+	OpQueue          *opqueue.MemQueue
 }
 
 // Protocol returns the ProtocolClient
@@ -51,16 +38,6 @@ func (m *ServerContext) Protocol() protocol.Client {
 // Blockchain returns the block chain client
 func (m *ServerContext) Blockchain() batch.BlockchainClient {
 	return m.BlockchainClient
-}
-
-// CAS returns the CAS client
-func (m *ServerContext) CAS() cas.Client {
-	return m.CasClient
-}
-
-// OperationStore returns the OperationStore client
-func (m *ServerContext) OperationStore() processor.OperationStoreClient {
-	return m.OperationStoreClient
 }
 
 // OperationQueue returns the queue containing the pending operations

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -9,14 +9,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch"
-	"github.com/trustbloc/sidetree-core-go/pkg/compression"
-	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler"
-
 	sidetreeobserver "github.com/trustbloc/sidetree-core-go/pkg/observer"
 )
 
@@ -53,11 +48,10 @@ func (l *ledger) RegisterForSidetreeTxn() <-chan []txn.SidetreeTxn {
 }
 
 // Start starts observer routines
-func Start(blockchainClient batch.BlockchainClient, cas cas.Client, operationStoreProvider sidetreeobserver.OperationStoreProvider, pcp protocol.ClientProvider) {
+func Start(blockchainClient batch.BlockchainClient, pcp protocol.ClientProvider) {
 	providers := &sidetreeobserver.Providers{
-		Ledger:          &ledger{blockChainClient: blockchainClient},
-		TxnOpsProvider:  txnhandler.NewOperationProvider(cas, pcp, compression.New(compression.WithDefaultAlgorithms())),
-		OpStoreProvider: operationStoreProvider,
+		Ledger:                 &ledger{blockChainClient: blockchainClient},
+		ProtocolClientProvider: pcp,
 	}
 
 	sidetreeobserver.New(providers).Start()

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200914191732-143e6dac7d0f
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200918194037-fdbce8c6dd49
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200914191732-143e6dac7d0f h1:w11QrvIZmSG+I24ZmKPFmBwqXeTXD08Q2fXOXJ05iuI=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200914191732-143e6dac7d0f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200918194037-fdbce8c6dd49 h1:jnwkj3Zf81yhQHUKpesDna4bRIBkk4moKtDyM1QPYB4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200918194037-fdbce8c6dd49/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
This latest version of sidetree-core-go implements protocol versioning.

closes #259

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>