### PR TITLE
chore: update sidetree-core (SIP-2, models versioned)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201014163439-6727b6a0dc5e
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201021135708-3d99cf53f9f9
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201014163439-6727b6a0dc5e h1:Dl+WLFxxYOH/4ud6e1R4URKngj+OXrjRjmP0c0Z2u8s=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201014163439-6727b6a0dc5e/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201021135708-3d99cf53f9f9 h1:PWJQDHe9RU7aTHMDyqLhGZ+udxQpOe4jiJLL5TYVRg8=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201021135708-3d99cf53f9f9/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/diddochandler"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/dochandler"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 
 	"github.com/trustbloc/sidetree-mock/pkg/mocks"
 )

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -128,7 +128,7 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 	parser := operationparser.New(latest)
 	cp := compression.New(compression.WithDefaultAlgorithms())
 	op := txnprovider.NewOperationProvider(latest, parser, m.casClient, cp)
-	th := txnprovider.NewOperationHandler(latest, m.casClient, cp)
+	th := txnprovider.NewOperationHandler(latest, m.casClient, cp, parser)
 	dc := doccomposer.New()
 	oa := operationapplier.New(latest, parser, dc)
 

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -6,7 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 package observer
 
 import (
-	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +16,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprovider/models"
 
 	"github.com/trustbloc/sidetree-mock/pkg/mocks"
@@ -61,7 +60,7 @@ func TestStartObserver(t *testing.T) {
 				return compress(&models.MapFile{Chunks: []models.Chunk{{ChunkFileURI: "chunkAddress"}}})
 			}
 			if key == "chunkAddress" {
-				return compress(&models.ChunkFile{Deltas: []string{getDelta()}})
+				return compress(&models.ChunkFile{Deltas: []*model.DeltaModel{getDelta()}})
 			}
 			return nil, nil
 		}}
@@ -124,19 +123,12 @@ func (m mockOperationStoreClient) Put(ops []*batch.AnchoredOperation) error {
 	return nil
 }
 
-func getSuffixData() string {
-	model := &model.SuffixDataModel{
+func getSuffixData() *model.SuffixDataModel {
+	return &model.SuffixDataModel{
 		DeltaHash: getEncodedMultihash([]byte(validDoc)),
 
 		RecoveryCommitment: getEncodedMultihash([]byte("commitment")),
 	}
-
-	bytes, err := json.Marshal(model)
-	if err != nil {
-		panic(err)
-	}
-
-	return docutil.EncodeToString(bytes)
 }
 
 func getEncodedMultihash(data []byte) string {
@@ -148,23 +140,16 @@ func getEncodedMultihash(data []byte) string {
 	return docutil.EncodeToString(mh)
 }
 
-func getDelta() string {
+func getDelta() *model.DeltaModel {
 	patches, err := patch.PatchesFromDocument(validDoc)
 	if err != nil {
 		panic(err)
 	}
 
-	model := &model.DeltaModel{
+	return &model.DeltaModel{
 		Patches:          patches,
 		UpdateCommitment: getEncodedMultihash([]byte("")),
 	}
-
-	bytes, err := json.Marshal(model)
-	if err != nil {
-		panic(err)
-	}
-
-	return docutil.EncodeToString(bytes)
 }
 
 func compress(model interface{}) ([]byte, error) {

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -10,10 +10,9 @@ echo "Running sidetree-mock integration tests..."
 PWD=`pwd`
 cd test/bddtests
 go test -count=1 -v -cover . -p 1 -timeout=20m -race
-# Interop tests are broken until at least SIP-2 is implemented (fixtures changed)
-#TAGS=interop_resolve_with_initial_value,interop_create_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
-#TAGS=interop_recover_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
-#TAGS=interop_deactivate_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
-#TAGS=interop_update_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
-#TAGS=interop_resolve_long_form_did go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_resolve_with_initial_value,interop_create_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_recover_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_deactivate_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_update_doc go test -count=1 -v -cover . -p 1 -timeout=20m -race
+TAGS=interop_resolve_long_form_did go test -count=1 -v -cover . -p 1 -timeout=20m -race
 cd $PWD

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -38,10 +38,11 @@ Feature:
     Then check success response contains "#aliasdid"
 
     When client sends request to create DID document with "patch" error
-    Then check error response contains "jsonpatch move operation does not apply"
+    Then check success response contains "#did"
+    Then check success response contains "#emptydoc"
 
     When client sends request to create DID document with "request" error
-    Then check error response contains "missing patches"
+    Then check error response contains "missing delta"
 
   @create_deactivate_did_doc
   Scenario: deactivate valid did doc
@@ -74,7 +75,7 @@ Feature:
     Then check success response contains "recoveryKey"
 
     When client sends request to recover DID document with "request" error
-    Then check error response contains "missing patches"
+    Then check error response contains "missing delta"
 
     @create_add_remove_public_key
     Scenario: add and remove public keys
@@ -104,7 +105,7 @@ Feature:
       When client sends request to resolve DID document
       Then check success response does NOT contain "newService"
       When client sends request to update DID document with "request" error
-      Then check error response contains "missing patches"
+      Then check error response contains "missing delta"
 
     @update_doc_error
     Scenario: handle update document errors
@@ -117,7 +118,7 @@ Feature:
       Then check success response contains "#did"
       Then check success response contains "createKey"
       When client sends request to update DID document with "request" error
-      Then check error response contains "missing patches"
+      Then check error response contains "missing delta"
 
 
 

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201014163439-6727b6a0dc5e
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201021135708-3d99cf53f9f9
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201014163439-6727b6a0dc5e h1:Dl+WLFxxYOH/4ud6e1R4URKngj+OXrjRjmP0c0Z2u8s=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201014163439-6727b6a0dc5e/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201021135708-3d99cf53f9f9 h1:PWJQDHe9RU7aTHMDyqLhGZ+udxQpOe4jiJLL5TYVRg8=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201021135708-3d99cf53f9f9/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Included:
- update sidetree-core version (SIP-2; models moved to versioned folder)
- enable interop tests

Closes #279

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>