### PR TITLE
chore: update sidetree-core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201026203103-ecf42b452242
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201026203103-ecf42b452242 h1:SRTEJkLBGvwXS6qtPQkf436ekLaJRpnbOfVCSa4iZms=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201026203103-ecf42b452242/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306 h1:etqa87qPU/5UJ/xFWvo/r7psEjZHDWox+mlQ/h9ybQ0=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/mocks/operationstore.go
+++ b/pkg/mocks/operationstore.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/observer"
 )
 
@@ -33,16 +33,16 @@ func (m *MockOpStoreProvider) ForNamespace(string) (observer.OperationStore, err
 // MockOperationStore is a mock operation store
 type MockOperationStore struct {
 	sync.RWMutex
-	operations map[string][]*batch.AnchoredOperation
+	operations map[string][]*operation.AnchoredOperation
 }
 
 // NewMockOperationStore returns a new mock operation store
 func NewMockOperationStore() *MockOperationStore {
-	return &MockOperationStore{operations: make(map[string][]*batch.AnchoredOperation)}
+	return &MockOperationStore{operations: make(map[string][]*operation.AnchoredOperation)}
 }
 
 // Put stores the given operations
-func (m *MockOperationStore) Put(ops []*batch.AnchoredOperation) error {
+func (m *MockOperationStore) Put(ops []*operation.AnchoredOperation) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -56,7 +56,7 @@ func (m *MockOperationStore) Put(ops []*batch.AnchoredOperation) error {
 }
 
 // Get retrieves the operations for the given suffix
-func (m *MockOperationStore) Get(suffix string) ([]*batch.AnchoredOperation, error) {
+func (m *MockOperationStore) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -111,18 +111,18 @@ func (m *MockProtocolClientProvider) ForNamespace(namespace string) (protocol.Cl
 func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:                  0,
-		HashAlgorithmInMultiHashCode: 18,
-		HashAlgorithm:                5, // crypto code for sha256 hash function
-		MaxOperationCount:            1, // one operation per batch - batch gets cut right away
-		MaxOperationSize:             200000,
-		CompressionAlgorithm:         "GZIP",
-		MaxChunkFileSize:             maxBatchFileSize,
-		MaxMapFileSize:               maxBatchFileSize,
-		MaxAnchorFileSize:            maxBatchFileSize,
-		Patches:                      []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
-		SignatureAlgorithms:          []string{"EdDSA", "ES256", "ES256K"},
-		KeyAlgorithms:                []string{"Ed25519", "P-256", "secp256k1"},
+		GenesisTime:          0,
+		MultihashAlgorithm:   18,
+		HashAlgorithm:        5, // crypto code for sha256 hash function
+		MaxOperationCount:    1, // one operation per batch - batch gets cut right away
+		MaxOperationSize:     200000,
+		CompressionAlgorithm: "GZIP",
+		MaxChunkFileSize:     maxBatchFileSize,
+		MaxMapFileSize:       maxBatchFileSize,
+		MaxAnchorFileSize:    maxBatchFileSize,
+		Patches:              []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		SignatureAlgorithms:  []string{"EdDSA", "ES256", "ES256K"},
+		KeyAlgorithms:        []string{"Ed25519", "P-256", "secp256k1"},
 	}
 
 	parser := operationparser.New(latest)

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -11,7 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
@@ -29,7 +30,7 @@ func TestStartObserver(t *testing.T) {
 		hits := 0
 
 		opStore := &mockOperationStoreClient{
-			putFunc: func(ops []*batch.AnchoredOperation) error {
+			putFunc: func(ops []*operation.AnchoredOperation) error {
 				rw.Lock()
 				defer rw.Unlock()
 
@@ -113,10 +114,10 @@ func (m mockCASClient) Read(key string) ([]byte, error) {
 }
 
 type mockOperationStoreClient struct {
-	putFunc func(ops []*batch.AnchoredOperation) error
+	putFunc func(ops []*operation.AnchoredOperation) error
 }
 
-func (m mockOperationStoreClient) Put(ops []*batch.AnchoredOperation) error {
+func (m mockOperationStoreClient) Put(ops []*operation.AnchoredOperation) error {
 	if m.putFunc != nil {
 		return m.putFunc(ops)
 	}

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -909,9 +909,9 @@ func (d *DIDSideSteps) processRequest(opType, path string) error {
 
 type InteropVectors struct {
 	Create     CreateOperationVectors `json:"create,omitempty"`
-	Update     OperationVectors `json:"update,omitempty"`
-	Recover    OperationVectors `json:"recover,omitempty"`
-	Deactivate OperationVectors `json:"deactivate,omitempty"`
+	Update     OperationVectors       `json:"update,omitempty"`
+	Recover    OperationVectors       `json:"recover,omitempty"`
+	Deactivate OperationVectors       `json:"deactivate,omitempty"`
 }
 
 type OperationVectors struct {
@@ -921,7 +921,7 @@ type OperationVectors struct {
 type CreateOperationVectors struct {
 	OperationVectors
 	ShortFormDID string `json:"shortFormDid,omitempty"`
-	LongFormDID string `json:"longFormDid,omitempty"`
+	LongFormDID  string `json:"longFormDid,omitempty"`
 }
 
 func (d *DIDSideSteps) resolveRequest(reqType, path string) error {
@@ -962,11 +962,6 @@ func (d *DIDSideSteps) processInteropResolveWithInitialValue() error {
 	return err
 }
 
-type longFormResolutionResult struct {
-	Status           string                    `json:"status,omitempty"`
-	ResolutionResult document.ResolutionResult `json:"body,omitempty"`
-}
-
 func (d *DIDSideSteps) validateResolutionResult(url string) error {
 	if d.resp.ErrorMsg != "" {
 		return errors.Errorf("error resp %s", d.resp.ErrorMsg)
@@ -978,23 +973,10 @@ func (d *DIDSideSteps) validateResolutionResult(url string) error {
 	}
 
 	var expected document.ResolutionResult
-	if url == "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/longFormResponse.json" {
 
-		// temporary struct until they fix issue #899
-		var temp longFormResolutionResult
-		err = json.Unmarshal(body, &temp)
-		if err != nil {
-			return err
-		}
-
-		expected = temp.ResolutionResult
-
-	} else {
-
-		err = json.Unmarshal(body, &expected)
-		if err != nil {
-			return err
-		}
+	err = json.Unmarshal(body, &expected)
+	if err != nil {
+		return err
 	}
 
 	prettyPrint(&expected)

--- a/test/bddtests/features/interop.feature
+++ b/test/bddtests/features/interop.feature
@@ -11,7 +11,7 @@ Feature:
     @interop_longform_create_update_doc
     Scenario: interop test for create/update operations and long form DID resolution
       When client sends "long-form-did" resolve request from "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/generated.json"
-      Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/longFormResponse.json"
+      Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/longFormResponseDidDocument.json"
 
       When client sends "create" operation request from "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/generated.json"
       Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterCreate.json"

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201026203103-ecf42b452242
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201026203103-ecf42b452242 h1:SRTEJkLBGvwXS6qtPQkf436ekLaJRpnbOfVCSa4iZms=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201026203103-ecf42b452242/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306 h1:etqa87qPU/5UJ/xFWvo/r7psEjZHDWox+mlQ/h9ybQ0=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Included:
- rename api/batch to api/operation
- remove public keys patch has ids field instead of public keys
- rename multihash algorithm field and tag
- clean-up of long form did resolution test (reference app vector issue got fixed)

Closes #286

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>