### PR TITLE
chore: add interop tests with exact match

### DIFF
--- a/cmd/sidetree-server/main.go
+++ b/cmd/sidetree-server/main.go
@@ -70,6 +70,11 @@ func main() {
 		methodCtx = strings.Split(config.GetString("did.method.context"), arrayDelimiter)
 	}
 
+	baseEnabled := false
+	if config.GetString("did.base.enabled") != "" {
+		baseEnabled = config.GetBool("did.base.enabled")
+	}
+
 	// create new batch writer
 	batchWriter, err := batch.New(didDocNamespace, ctx)
 	if err != nil {
@@ -88,7 +93,7 @@ func main() {
 		didDocNamespace,
 		aliases,
 		pc,
-		didtransformer.New(didtransformer.WithMethodContext(methodCtx)),
+		didtransformer.New(didtransformer.WithMethodContext(methodCtx), didtransformer.WithBase(baseEnabled)),
 		batchWriter,
 		processor.New(didDocNamespace, opStore, pc),
 	)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201029224912-2c4c336bf323
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306 h1:etqa87qPU/5UJ/xFWvo/r7psEjZHDWox+mlQ/h9ybQ0=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201029224912-2c4c336bf323 h1:xOKv6VaQh97VEuyzUTv7rkiAhN0fF7BxE33WLT/D29o=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201029224912-2c4c336bf323/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/test/bddtests/features/interop.feature
+++ b/test/bddtests/features/interop.feature
@@ -11,19 +11,20 @@ Feature:
     @interop_longform_create_update_doc
     Scenario: interop test for create/update operations and long form DID resolution
       When client sends "long-form-did" resolve request from "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/generated.json"
-      Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/longFormResponseDidDocument.json"
+      Then success response matches resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/longFormResponseDidDocument.json"
 
       When client sends "create" operation request from "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/generated.json"
       Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterCreate.json"
 
       Then we wait 1 seconds
       When client sends request to resolve DID document
-      Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterCreate.json"
+      Then success response matches resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterCreate.json"
 
       When client sends "update" operation request from "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/generated.json"
 
       Then we wait 1 seconds
       When client sends request to resolve DID document
+      # Then success response matches resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterUpdate.json"
       Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterUpdate.json"
 
     @interop_create_recover_deactivate_doc
@@ -38,6 +39,7 @@ Feature:
 
       Then we wait 1 seconds
       When client sends request to resolve DID document
+      # Then success response matches resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterRecover.json"
       Then success response is validated against resolution result "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/resolution/afterRecover.json"
 
       When client sends "deactivate" operation request from "https://raw.githubusercontent.com/decentralized-identity/sidetree/master/tests/vectors/generated.json"

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       - SIDETREE_MOCK_PORT=48326
       - SIDETREE_MOCK_DID_NAMESPACE=did:sidetree
       - SIDETREE_MOCK_DID_ALIASES=did:alias.com,did:domain.com
-      - SIDETREE_MOCK_DID_METHOD_CONTEXT=https://trustbloc.github.io/context/did/trustbloc-v1.jsonld
+      - SIDETREE_MOCK_DID_METHOD_CONTEXT=
+      - SIDETREE_MOCK_DID_BASE_ENABLED=true
     ports:
       - 48326:48326
     volumes:

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201029224912-2c4c336bf323
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306 h1:etqa87qPU/5UJ/xFWvo/r7psEjZHDWox+mlQ/h9ybQ0=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201028222733-bf0c34b40306/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201029224912-2c4c336bf323 h1:xOKv6VaQh97VEuyzUTv7rkiAhN0fF7BxE33WLT/D29o=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201029224912-2c4c336bf323/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Sidetree-core has been updated to support optional @base property. Now we can have exact match tests against reference application.

Note: two interop tests for exact match are commented out until reference application fixes https://github.com/decentralized-identity/sidetree/issues/905

Closes #287

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>