### PR TITLE
chore: signed data loaded from proof files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201111115036-54dcc46d4ee1
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201115064014-3f2a73a9b516
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201111115036-54dcc46d4ee1 h1:HF6ZnQLt9SfXZXP74tN0yagXuOQE1LjXbG3LfKOphKI=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201111115036-54dcc46d4ee1/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201115064014-3f2a73a9b516 h1:qlHfH5j8U7rl69Ou9YB0vwhA5xm3Cj9Rh66JrpJ/Q0s=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201115064014-3f2a73a9b516/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -111,18 +111,18 @@ func (m *MockProtocolClientProvider) ForNamespace(namespace string) (protocol.Cl
 func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:          0,
-		MultihashAlgorithm:   18,
-		MaxOperationCount:    1, // one operation per batch - batch gets cut right away
-		MaxOperationSize:     200000,
-		CompressionAlgorithm: "GZIP",
-		MaxChunkFileSize:     maxBatchFileSize,
-		MaxMapFileSize:       maxBatchFileSize,
-		MaxAnchorFileSize:    maxBatchFileSize,
-		MaxProofFileSize:     maxBatchFileSize,
-		Patches:              []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
-		SignatureAlgorithms:  []string{"EdDSA", "ES256", "ES256K"},
-		KeyAlgorithms:        []string{"Ed25519", "P-256", "secp256k1"},
+		GenesisTime:                 0,
+		MultihashAlgorithm:          18,
+		MaxOperationCount:           1, // one operation per batch - batch gets cut right away
+		MaxOperationSize:            200000,
+		CompressionAlgorithm:        "GZIP",
+		MaxChunkFileSize:            maxBatchFileSize,
+		MaxProvisionalIndexFileSize: maxBatchFileSize,
+		MaxCoreIndexFileSize:        maxBatchFileSize,
+		MaxProofFileSize:            maxBatchFileSize,
+		Patches:                     []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		SignatureAlgorithms:         []string{"EdDSA", "ES256", "ES256K"},
+		KeyAlgorithms:               []string{"Ed25519", "P-256", "secp256k1"},
 	}
 
 	parser := operationparser.New(latest)

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -56,14 +56,14 @@ func TestStartObserver(t *testing.T) {
 
 		casClient := mockCASClient{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return compress(&models.AnchorFile{MapFileURI: "mapAddress",
-					Operations: models.Operations{
+				return compress(&models.CoreIndexFile{ProvisionalIndexFileURI: "provisionalIndexAddress",
+					Operations: models.CoreOperations{
 						Create: []models.CreateOperation{{
 							SuffixData: getSuffixData(),
 						}}}})
 			}
-			if key == "mapAddress" {
-				return compress(&models.MapFile{Chunks: []models.Chunk{{ChunkFileURI: "chunkAddress"}}})
+			if key == "provisionalIndexAddress" {
+				return compress(&models.ProvisionalIndexFile{Chunks: []models.Chunk{{ChunkFileURI: "chunkAddress"}}})
 			}
 			if key == "chunkAddress" {
 				return compress(&models.ChunkFile{Deltas: []*model.DeltaModel{getDelta()}})
@@ -152,14 +152,14 @@ func getDelta() *model.DeltaModel {
 		panic(err)
 	}
 
-	updateCommitment, err := commitment.Calculate(&jws.JWK{}, sha2_256)
+	c, err := commitment.Calculate(&jws.JWK{}, sha2_256)
 	if err != nil {
 		panic(err)
 	}
 
 	return &model.DeltaModel{
 		Patches:          patches,
-		UpdateCommitment: updateCommitment,
+		UpdateCommitment: c,
 	}
 }
 

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -86,7 +86,7 @@ const docTemplate = `{
      "publicKeyJwk": %s
    },
    {
-     "id": "dual-assertion-gen",
+     "id": "auth",
      "type": "Ed25519VerificationKey2018",
      "purposes": ["assertionMethod"],
      "publicKeyJwk": %s

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201111115036-54dcc46d4ee1
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201115064014-3f2a73a9b516
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201111115036-54dcc46d4ee1 h1:HF6ZnQLt9SfXZXP74tN0yagXuOQE1LjXbG3LfKOphKI=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201111115036-54dcc46d4ee1/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201115064014-3f2a73a9b516 h1:qlHfH5j8U7rl69Ou9YB0vwhA5xm3Cj9Rh66JrpJ/Q0s=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201115064014-3f2a73a9b516/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Update sidetree-core:
- signed data loaded from proof files
- renamed anchor/map file to core/provisional index
- adjusted protocol parameter names accordingly
- kid MAY be present in the protected headers

Closes #295

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>