### PR TITLE
chore: update sidetree-core (SIP-1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201121214727-f4aa16b5a990
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201126220537-656a5c8a3bdf
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201121214727-f4aa16b5a990 h1:8ay/JbW4MqYWdXSKcsv+hVK9t80CcB17HQOUV3T6MvY=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201121214727-f4aa16b5a990/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201126220537-656a5c8a3bdf h1:+4t+XwM18xQjJuajZvfyGkVUuxMyYJhLWb4ytdF3QU4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201126220537-656a5c8a3bdf/go.mod h1:R+nPCnM51WBtAgZ+xSbyiLlDDIuEp419K6gWb3Hl6cY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -265,21 +265,33 @@ func (h *sampleResolveHandler) Handler() common.HTTPRequestHandler {
 }
 
 func getCreateRequest() ([]byte, error) {
-	testKey := &jws.JWK{
+	updateKey := &jws.JWK{
 		Crv: "crv",
 		Kty: "kty",
 		X:   "x",
 	}
 
-	c, err := commitment.Calculate(testKey, sha2_256)
+	recoveryKey := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+		Y:   "y",
+	}
+
+	updateCommitment, err := commitment.Calculate(updateKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
+	recoveryCommitment, err := commitment.Calculate(recoveryKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
 	info := &client.CreateRequestInfo{
 		OpaqueDocument:     validDoc,
-		RecoveryCommitment: c,
-		UpdateCommitment:   c,
+		RecoveryCommitment: recoveryCommitment,
+		UpdateCommitment:   updateCommitment,
 		MultihashCode:      sha2_256,
 	}
 	return client.NewCreateRequest(info)

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -131,7 +131,7 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 		GenesisTime:                 0,
 		MultihashAlgorithm:          18,
 		MaxOperationCount:           1, // one operation per batch - batch gets cut right away
-		MaxOperationSize:            200000,
+		MaxOperationSize:            2000,
 		CompressionAlgorithm:        "GZIP",
 		MaxChunkFileSize:            maxBatchFileSize,
 		MaxProvisionalIndexFileSize: maxBatchFileSize,

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -57,8 +57,8 @@ func TestStartObserver(t *testing.T) {
 		casClient := mockCASClient{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
 				return compress(&models.CoreIndexFile{ProvisionalIndexFileURI: "provisionalIndexAddress",
-					Operations: models.CoreOperations{
-						Create: []models.CreateOperation{{
+					Operations: &models.CoreOperations{
+						Create: []models.CreateReference{{
 							SuffixData: getSuffixData(),
 						}}}})
 			}

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -724,7 +724,7 @@ func (d *DIDSideSteps) getUpdateRequest(did string, patches []patch.Patch) ([]by
 		UpdateKey:        updatePubKey,
 		Patches:          patches,
 		MultihashCode:    sha2_256,
-		Signer:           ecsigner.New(d.updateKey, "ES256", "update-kid"),
+		Signer:           ecsigner.New(d.updateKey, "ES256", ""),
 	})
 
 	if err != nil {

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201121214727-f4aa16b5a990
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201126220537-656a5c8a3bdf
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201121214727-f4aa16b5a990 h1:8ay/JbW4MqYWdXSKcsv+hVK9t80CcB17HQOUV3T6MvY=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201121214727-f4aa16b5a990/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201126220537-656a5c8a3bdf h1:+4t+XwM18xQjJuajZvfyGkVUuxMyYJhLWb4ytdF3QU4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201126220537-656a5c8a3bdf/go.mod h1:R+nPCnM51WBtAgZ+xSbyiLlDDIuEp419K6gWb3Hl6cY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Included:
- SIP-1
- Checks for commitment re-use within an operation (client, server side)
- Align interfaces/code with anticipated pruning/checkpoint requirements
- Remove "kid must be present in protected header" rule in the client
- Max operation size parameter similar to protocol (1 vs 2 kilobytes - it fails)

Closes #301

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>