### PR TITLE
chore: update sidetree-core (max delta, proof, hash, cas uri)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201201191641-21b7fc4cc94d
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201203160228-bad37e299892
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201201191641-21b7fc4cc94d h1:6+OmN/9MrZMA4b2CEXRJFQGxf/5gjUEqdnPjOczMMpg=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201201191641-21b7fc4cc94d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201203160228-bad37e299892 h1:iQuV0H5jDBulx2+kFEznyeQm2WKPZ17yApOLe5eag74=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201203160228-bad37e299892/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -130,8 +130,12 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 	latest := protocol.Protocol{
 		GenesisTime:                 0,
 		MultihashAlgorithm:          18,
-		MaxOperationCount:           1, // one operation per batch - batch gets cut right away
-		MaxOperationSize:            2000,
+		MaxOperationCount:           1,    // one operation per batch - batch gets cut right away
+		MaxOperationSize:            2500, // has to be bigger than max delta + max proof + small number for type
+		MaxOperationHashLength:      100,
+		MaxDeltaSize:                1700, // interop tests pass for 1000, our test is about 1100 since we have multiple public keys/services
+		MaxProofSize:                700,  // currently it is bellow 500
+		MaxCasURILength:             100,
 		CompressionAlgorithm:        "GZIP",
 		MaxChunkFileSize:            maxBatchFileSize,
 		MaxProvisionalIndexFileSize: maxBatchFileSize,

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -1133,7 +1133,7 @@ func validateService(expected, service document.Service) error {
 	return nil
 }
 
-func validateMetadata(expected, metadata document.MethodMetadata) error {
+func validateMetadata(expected, metadata document.Metadata) error {
 	if expected[document.RecoveryCommitmentProperty] != metadata[document.RecoveryCommitmentProperty]  {
 		return fmt.Errorf("recovery commitment mismatch: expected[%s], got[%s]", expected[document.RecoveryCommitmentProperty] , metadata[document.RecoveryCommitmentProperty])
 	}

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201201191641-21b7fc4cc94d
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20201203160228-bad37e299892
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201201191641-21b7fc4cc94d h1:6+OmN/9MrZMA4b2CEXRJFQGxf/5gjUEqdnPjOczMMpg=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20201201191641-21b7fc4cc94d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201203160228-bad37e299892 h1:iQuV0H5jDBulx2+kFEznyeQm2WKPZ17yApOLe5eag74=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20201203160228-bad37e299892/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Included:
- new protocol parameters: max delta, max proof, max hash plus related REST validation and batch validation
- validation of max operation size moved to operation parser (before un-marshalling)
- move canonicalId to did document metadata
- validate CAS file URIs (new protocol parameter max CAS URI length)
- add-services will now fail if there are duplicate services
- advance update commitment if possible

Closes #305

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>