### PR TITLE
chore: update sidetree-core (reveal value added to requests)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -278,12 +278,12 @@ func getCreateRequest() ([]byte, error) {
 		Y:   "y",
 	}
 
-	updateCommitment, err := commitment.Calculate(updateKey, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
-	recoveryCommitment, err := commitment.Calculate(recoveryKey, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(recoveryKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -129,12 +129,11 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
 		GenesisTime:                 0,
-		MultihashAlgorithm:          18,
+		MultihashAlgorithms:         []uint{18},
 		MaxOperationCount:           1,    // one operation per batch - batch gets cut right away
 		MaxOperationSize:            2500, // has to be bigger than max delta + max proof + small number for type
 		MaxOperationHashLength:      100,
 		MaxDeltaSize:                1700, // interop tests pass for 1000, our test is about 1100 since we have multiple public keys/services
-		MaxProofSize:                700,  // currently it is bellow 500
 		MaxCasURILength:             100,
 		CompressionAlgorithm:        "GZIP",
 		MaxChunkFileSize:            maxBatchFileSize,

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -135,7 +135,7 @@ func getSuffixData() *model.SuffixDataModel {
 		panic(err)
 	}
 
-	recoveryCommitment, err := commitment.Calculate(&jws.JWK{}, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(&jws.JWK{}, sha2_256)
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func getDelta() *model.DeltaModel {
 		panic(err)
 	}
 
-	c, err := commitment.Calculate(&jws.JWK{}, sha2_256)
+	c, err := commitment.GetCommitment(&jws.JWK{}, sha2_256)
 	if err != nil {
 		panic(err)
 	}

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -646,8 +646,14 @@ func (d *DIDSideSteps) getRecoverRequest(doc []byte, patches []patch.Patch, uniq
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(recoveryPubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	recoverRequest, err := client.NewRecoverRequest(&client.RecoverRequestInfo{
 		DidSuffix:          uniqueSuffix,
+		RevealValue:        revealValue,
 		OpaqueDocument:     string(doc),
 		Patches:            patches,
 		RecoveryKey:        recoveryPubKey,
@@ -708,8 +714,14 @@ func (d *DIDSideSteps) getDeactivateRequest(did string) ([]byte, error) {
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(recoveryPubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	return client.NewDeactivateRequest(&client.DeactivateRequestInfo{
 		DidSuffix:   did,
+		RevealValue: revealValue,
 		RecoveryKey: recoveryPubKey,
 		Signer:      ecsigner.New(d.recoveryKey, "ES256", ""),
 	})
@@ -727,8 +739,14 @@ func (d *DIDSideSteps) getUpdateRequest(did string, patches []patch.Patch) ([]by
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(updatePubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := client.NewUpdateRequest(&client.UpdateRequestInfo{
 		DidSuffix:        did,
+		RevealValue:      revealValue,
 		UpdateCommitment: updateCommitment,
 		UpdateKey:        updatePubKey,
 		Patches:          patches,
@@ -772,7 +790,7 @@ func generateKeyAndCommitment() (*ecdsa.PrivateKey, string, error) {
 		return nil, "", err
 	}
 
-	c, err := commitment.Calculate(pubKey, sha2_256)
+	c, err := commitment.GetCommitment(pubKey, sha2_256)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1134,8 +1152,8 @@ func validateService(expected, service document.Service) error {
 }
 
 func validateMetadata(expected, metadata document.Metadata) error {
-	if expected[document.RecoveryCommitmentProperty] != metadata[document.RecoveryCommitmentProperty]  {
-		return fmt.Errorf("recovery commitment mismatch: expected[%s], got[%s]", expected[document.RecoveryCommitmentProperty] , metadata[document.RecoveryCommitmentProperty])
+	if expected[document.RecoveryCommitmentProperty] != metadata[document.RecoveryCommitmentProperty] {
+		return fmt.Errorf("recovery commitment mismatch: expected[%s], got[%s]", expected[document.RecoveryCommitmentProperty], metadata[document.RecoveryCommitmentProperty])
 	}
 
 	if expected[document.UpdateCommitmentProperty] != metadata[document.UpdateCommitmentProperty] {

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -38,8 +38,7 @@ Feature:
     Then check success response contains "#aliasdid"
 
     When client sends request to create DID document with "patch" error
-    Then check success response contains "#did"
-    Then check success response contains "#emptydoc"
+    Then check error response contains "applying delta resulted in an empty document (most likely due to an invalid patch)"
 
     When client sends request to create DID document with "request" error
     Then check error response contains "missing delta"

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Complete SIP-1:
- add reveal value in update, reveal, deactivate operations
- support multiple multi-hashing algorithms in protocol
- remove max proof size protocol parameter

Also, added REST API check to fail create if applying patches results in an empty document (due to an error or invalid usage)

Closes #311

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>