### PR TITLE
chore: Add BDD test for reusing keys for did operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886 h1:0j2yds0mD6jpTsozEXC8q8vOv/6COXQGR4BgbVuEuF4=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac h1:pkL6ScFXQbjXL1SCYbNfHf/FylshBiKa+399+RR6mco=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -143,6 +143,7 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 		Patches:                     []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 		SignatureAlgorithms:         []string{"EdDSA", "ES256", "ES256K"},
 		KeyAlgorithms:               []string{"Ed25519", "P-256", "secp256k1"},
+		NonceSize:                   16,
 	}
 
 	parser := operationparser.New(latest)

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -119,5 +119,33 @@ Feature:
       When client sends request to update DID document with "request" error
       Then check error response contains "missing delta"
 
+  @reuse_keys_for_did_operations
+  Scenario: reuse keys for did operations
+    When client sets reuse keys for did operations to "true"
 
+    When client sends request to create DID document
+    Then check success response contains "#did"
+    Then we wait 1 seconds
 
+    When client sends request to add public key with ID "newKey" to DID document
+    Then we wait 1 seconds
+    When client sends request to resolve DID document
+    Then check success response contains "newKey"
+
+    When client sends request to recover DID document
+    Then we wait 1 seconds
+    When client sends request to resolve DID document
+    Then check success response contains "recoveryKey"
+
+    When client sends request to add public key with ID "newKey2" to DID document
+    Then we wait 1 seconds
+    When client sends request to resolve DID document
+    Then check success response contains "newKey2"
+
+    When client sends request to deactivate DID document
+    Then we wait 1 seconds
+    When client sends request to resolve DID document
+    Then check success response contains "deactivated"
+
+    # reset flag back to false for other tests
+    When client sets reuse keys for did operations to "false"

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886 h1:0j2yds0mD6jpTsozEXC8q8vOv/6COXQGR4BgbVuEuF4=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac h1:pkL6ScFXQbjXL1SCYbNfHf/FylshBiKa+399+RR6mco=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Update sidetree-core and add integration tests for re-using keys for did operations.

Closes #324

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>