### PR TITLE
chore: update sidetree-core (decompression factor, handler endpoints)

### DIFF
--- a/cmd/sidetree-server/main.go
+++ b/cmd/sidetree-server/main.go
@@ -32,7 +32,10 @@ var logger = logrus.New()
 var config = viper.New()
 
 const defaultDIDDocNamespace = "did:sidetree"
-const basePath = "/sidetree/0.0.1"
+
+const operationPath = "/sidetree/0.0.1/operations"
+const resolutionPath = "/sidetree/0.0.1/identifiers"
+
 const arrayDelimiter = ","
 
 func main() {
@@ -101,8 +104,8 @@ func main() {
 		config.GetString("tls.certificate"),
 		config.GetString("tls.key"),
 		config.GetString("api.token"),
-		diddochandler.NewUpdateHandler(basePath, didDocHandler, pc),
-		diddochandler.NewResolveHandler(basePath, didDocHandler),
+		diddochandler.NewUpdateHandler(operationPath, didDocHandler, pc),
+		diddochandler.NewResolveHandler(resolutionPath, didDocHandler),
 	)
 
 	if restSvc.Start() != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210301232849-50c4792e1ca1
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac h1:pkL6ScFXQbjXL1SCYbNfHf/FylshBiKa+399+RR6mco=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210301232849-50c4792e1ca1 h1:nHhN9RbX4aiZ90y+g5rmJwCdS+OgT0WWTtRfNX1D4J8=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210301232849-50c4792e1ca1/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/diddochandler"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/dochandler"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/client"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/model"
 
 	"github.com/trustbloc/sidetree-mock/pkg/mocks"
 )
@@ -62,8 +62,8 @@ func TestServer_Start(t *testing.T) {
 		"",
 		"",
 		"tk1",
-		diddochandler.NewUpdateHandler(basePath, didDocHandler, pc),
-		diddochandler.NewResolveHandler(basePath, didDocHandler),
+		diddochandler.NewUpdateHandler(baseUpdatePath, didDocHandler, pc),
+		diddochandler.NewResolveHandler(baseResolvePath, didDocHandler),
 		newSampleUpdateHandler(sampleDocHandler, pc),
 		newSampleResolveHandler(sampleDocHandler),
 	)

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -15,13 +15,13 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/processor"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doccomposer"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doctransformer/didtransformer"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/docvalidator/didvalidator"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationapplier"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationparser"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprocessor"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprovider"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/doccomposer"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/doctransformer/didtransformer"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/docvalidator/didvalidator"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/operationapplier"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/operationparser"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/txnprocessor"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/txnprovider"
 )
 
 // DefaultNS is default namespace used in mocks
@@ -128,22 +128,23 @@ func (m *MockProtocolClientProvider) ForNamespace(namespace string) (protocol.Cl
 func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:                 0,
-		MultihashAlgorithms:         []uint{18},
-		MaxOperationCount:           1,    // one operation per batch - batch gets cut right away
-		MaxOperationSize:            2500, // has to be bigger than max delta + max proof + small number for type
-		MaxOperationHashLength:      100,
-		MaxDeltaSize:                1700, // interop tests pass for 1000, our test is about 1100 since we have multiple public keys/services
-		MaxCasURILength:             100,
-		CompressionAlgorithm:        "GZIP",
-		MaxChunkFileSize:            maxBatchFileSize,
-		MaxProvisionalIndexFileSize: maxBatchFileSize,
-		MaxCoreIndexFileSize:        maxBatchFileSize,
-		MaxProofFileSize:            maxBatchFileSize,
-		Patches:                     []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
-		SignatureAlgorithms:         []string{"EdDSA", "ES256", "ES256K"},
-		KeyAlgorithms:               []string{"Ed25519", "P-256", "secp256k1"},
-		NonceSize:                   16,
+		GenesisTime:                  0,
+		MultihashAlgorithms:          []uint{18},
+		MaxOperationCount:            1,    // one operation per batch - batch gets cut right away
+		MaxOperationSize:             2500, // has to be bigger than max delta + max proof + small number for type
+		MaxOperationHashLength:       100,
+		MaxDeltaSize:                 1700, // interop tests pass for 1000, our test is about 1100 since we have multiple public keys/services
+		MaxCasURILength:              100,
+		CompressionAlgorithm:         "GZIP",
+		MaxChunkFileSize:             maxBatchFileSize,
+		MaxProvisionalIndexFileSize:  maxBatchFileSize,
+		MaxCoreIndexFileSize:         maxBatchFileSize,
+		MaxProofFileSize:             maxBatchFileSize,
+		Patches:                      []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		SignatureAlgorithms:          []string{"EdDSA", "ES256", "ES256K"},
+		KeyAlgorithms:                []string{"Ed25519", "P-256", "secp256k1"},
+		NonceSize:                    16,
+		MaxMemoryDecompressionFactor: 3,
 	}
 
 	parser := operationparser.New(latest)

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/hashing"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprovider/models"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/model"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/txnprovider/models"
 
 	"github.com/trustbloc/sidetree-mock/pkg/mocks"
 )

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -34,8 +34,8 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/client"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/model"
 	"github.com/trustbloc/sidetree-mock/test/bddtests/restclient"
 )
 

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210301232849-50c4792e1ca1
 )
 
 go 1.13

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac h1:pkL6ScFXQbjXL1SCYbNfHf/FylshBiKa+399+RR6mco=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210226160955-0f2eb26106ac/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210301232849-50c4792e1ca1 h1:nHhN9RbX4aiZ90y+g5rmJwCdS+OgT0WWTtRfNX1D4J8=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210301232849-50c4792e1ca1/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Update sidetree-core:
- new decompression factor protocol paramters
- handler endpoints should be passed in to core operation and resolution handlers
- renamed versions folder from 0_1 to 1_0

Closes #326

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>